### PR TITLE
fix leak

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -26,6 +26,7 @@ my $build = Module::Build::Pluggable->new(
         'Test::RedisServer' => '0.12',
         'Test::TCP'         => '1.18',
         'Test::Deep'        => 0,
+        'Devel::Refcount'   => 0,
     },
     include_dirs       => ['src', 'deps/hiredis', "${installsitearch}/EV", $installsitearch],
     xs_files           => { 'src/EV__Hiredis.xs' => 'lib/EV/Hiredis.xs' },

--- a/t/leak.t
+++ b/t/leak.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::RedisServer;
+use Test::LeakTrace;
+use Devel::Peek qw/SvREFCNT/;
+use Devel::Refcount qw/refcount/;
+my $redis_server;
+eval {
+    $redis_server = Test::RedisServer->new;
+} or plan skip_all => 'redis-server is required to this test';
+
+plan tests => 3;
+
+my %connect_info = $redis_server->connect_info;
+
+use EV;
+use EV::Hiredis;
+
+my $r = EV::Hiredis->new( path => $connect_info{sock} );
+my ($get_command, $test);
+my $result;
+$get_command = sub {
+    $r->lrange('foo', 0, -1, sub {
+        $result = shift;
+        $r->lrange('foo', 0, -1, $test);
+        $get_command = undef;
+    });
+};
+$test = sub {
+    is refcount($result), 2, 'reference count of array is 2(no_leaks_ok and $test)';
+    is SvREFCNT($result->[0]), 1, 'reference count of first element is 1';
+    is SvREFCNT($result->[1]), 1, 'reference count of second element is 1';
+    $r->disconnect;
+};
+$r->rpush('foo' => 'bar1', sub {
+    $r->rpush('foo' => 'bar2', $get_command);
+});
+EV::run;
+
+done_testing;


### PR DESCRIPTION
Following code leaks memory with EV-Hiredis 0.02

``` perl
use EV::Hiredis;

my $redis = EV::Hiredis->new;
$redis->connect('127.0.0.1');

sub get_from_redis {
    $redis->get('foo', \&get_from_redis);
}

# command
$redis->set('foo' => 'bar' x 10000, sub {
    get_from_redis();
});

# start main loop
EV::run;
```

My request will fix it.
