### PR TITLE
set module maker to ModuleBuild

### DIFF
--- a/minil.toml
+++ b/minil.toml
@@ -1,4 +1,5 @@
 [build]
+module_maker = "ModuleBuild"
 build_class = "builder::MyBuilder"
 [no_index]
 directory = ['t', 'xt', 'inc', 'share', 'eg', 'examples', 'author', 'builder', 'deps']


### PR DESCRIPTION
fix the following warnings:

```
Run minil test --all
!
! WARNING:
! module_maker is not set in your Minilla config (minil.toml), but found [build] or [XSUtil] section in it.
! Defaulting to Module::Build, but you're suggested to add the following to your minil.toml:
!
!   module_maker="ModuleBuild"
!
! This friendly warning will go away in the next major release, and Minilla will default to ModuleBuildTiny
! when module_maker is not explicitly set in minil.toml.
!
```